### PR TITLE
Allow fallback when checking for guests only, and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can control the config settings in your `.env` file as such:
 - `LSCACHE_ESI_ENABLED` - accepts `true` or `false` to whether you want ESI enabled or not globally; Default `false`
 - `LSCACHE_DEFAULT_TTL` - accepts an integer, this value is in seconds; Default: `0`
 - `LSCACHE_DEFAULT_CACHEABILITY` - accepts a string, you can use values such as `private`, `no-cache`, `public` or `no-vary`; Default: `no-cache`
+- `LSCACHE_GUEST_ONLY` - accepts `true` or `false` to decide if the cache should be enabled for guests only; Defaults to `false`
 
 You set the cache-control header for lscache using a middleware, so we can in our routes do something like this:
 

--- a/src/LSCacheMiddleware.php
+++ b/src/LSCacheMiddleware.php
@@ -3,37 +3,37 @@
 namespace Litespeed\LSCache;
 
 use Closure;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 
 class LSCacheMiddleware
 {
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @param  string $lscache_control
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure                 $next
+     * @param  string                   $lscache_control
      * @return mixed
      */
     public function handle($request, Closure $next, string $lscache_control = null)
     {
         $response = $next($request);
 
-        if (! $request->isMethodCacheable() || ! $response->getContent()) {
+        if ( ! $request->isMethodCacheable() || ! $response->getContent()) {
             return $response;
         }
 
         $esi_enabled    = config('lscache.esi');
         $maxage         = config('lscache.default_ttl');
         $cacheability   = config('lscache.default_cacheability');
-        $guest_only     = config('lscache.guest_only');
+        $guest_only     = config('lscache.guest_only', false);
 
-        if($maxage === 0 && $lscache_control === null) {
+        if ($maxage === 0 && $lscache_control === null) {
             return $response;
         }
 
-        if($guest_only == true && Auth::check() == true) {
+        if ($guest_only && Auth::check()) {
             $response->headers->set('X-LiteSpeed-Cache-Control', 'no-cache');
 
             return $response;
@@ -41,15 +41,15 @@ class LSCacheMiddleware
 
         $lscache_string = "max-age=$maxage,$cacheability";
 
-        if(isset($lscache_control)) {
+        if (isset($lscache_control)) {
             $lscache_string = str_replace(';', ',', $lscache_control);
         }
 
-        if(Str::contains($lscache_string, 'esi=on') == false) {
-            $lscache_string = $lscache_string  . ($esi_enabled ? ',esi=on' : null);
+        if (Str::contains($lscache_string, 'esi=on') == false) {
+            $lscache_string = $lscache_string.($esi_enabled ? ',esi=on' : null);
         }
 
-        if($response->headers->has('X-LiteSpeed-Cache-Control') == false) {
+        if ($response->headers->has('X-LiteSpeed-Cache-Control') == false) {
             $response->headers->set('X-LiteSpeed-Cache-Control', $lscache_string);
         }
 


### PR DESCRIPTION
Here's a summary of the changes in this commit:

- documents the `LSCACHE_GUEST_ONLY` config setting;
- allows for a default fallback in the middleware to false when checking for the guest only option (this is to prevent any issues when the user hasn't updated/added his config/env setting)'
- minor change to how the `guest_only` and `Auth::check` are determined as there's no need to use `== true`;

Improves https://github.com/litespeedtech/lscache-laravel/commit/243cbe985c93d1e011b7cff82bfd442e4afbba0c, which in turn addresses #7 
