### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/LSCacheMiddleware.php
+++ b/src/LSCacheMiddleware.php
@@ -16,7 +16,7 @@ class LSCacheMiddleware
      * @param  string                   $lscache_control
      * @return mixed
      */
-    public function handle($request, Closure $next, string $lscache_control = null)
+    public function handle($request, Closure $next, ?string $lscache_control = null)
     {
         $response = $next($request);
 

--- a/src/LSTagsMiddleware.php
+++ b/src/LSTagsMiddleware.php
@@ -14,7 +14,7 @@ class LSTagsMiddleware
      * @param  string $lscache_tags
      * @return mixed
      */
-    public function handle($request, Closure $next, string $lscache_tags = null)
+    public function handle($request, Closure $next, ?string $lscache_tags = null)
     {
         $response = $next($request);
 


### PR DESCRIPTION
Resolving PHP 8.4 depreciation messages: `Implicitly marking parameter ... as nullable is deprecated, the explicit nullable type must be used instead`