### PR TITLE
Support Laravel 10–13 and Octane-safe LSCache purge headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 ## Laravel LSCache
 
-This package allows you to use lscache together with Laravel.
+This package allows you to use LSCache together with Laravel. It works with both **LiteSpeed Web Server** (all editions, including the free OpenLiteSpeed) and the commercial **LiteSpeed Enterprise** server.
 
 It provides two middlewares and one facade:
 
 - LSCache Middleware to control the cache-control header for LiteSpeed LSCache
 - LSTags Middleware to control the tag header for LiteSpeed LSCache
 - LSCache facade to handle purging
+
+## Requirements
+
+| Package version | Laravel | PHP   |
+|-----------------|---------|-------|
+| 2.x             | 10 – 13 | ≥ 8.1 |
 
 ## Installation
 
@@ -18,42 +24,7 @@ composer require litespeed/lscache-laravel
 
 Laravel uses Auto-Discovery, so you won't have to make any changes to your application, the two middlewares and facade will be available right from the beginning.
 
-#### Steps for Laravel >=5.1 and <=5.4
-
-The package can be used for Laravel 5.1 to 5.4 as well, however due to lack of Auto-Discovery, a few additional steps have to be performed.
-
-In `config/app.php` you have to add the following code in your `aliases`:
-
-```
-'aliases' => [
-    ...
-    'LSCache'   => Litespeed\LSCache\LSCache::class,
-],
-```
-
-In `app/Http/Kernel.php` you have to add the two middlewares under `middleware` and `routeMiddleware`:
-
-```
-protected $middleware = [
-    ...
-    \Litespeed\LSCache\LSCacheMiddleware::class,
-    \Litespeed\LSCache\LSTagsMiddleware::class,
-];
-
-protected $routeMiddleware = [
-    ...
-    'lscache' => \Litespeed\LSCache\LSCacheMiddleware::class,
-    'lstags' => \Litespeed\LSCache\LSTagsMiddleware::class,
-];
-```
-
-Copy `lscache.php` to `config/`:
-
-Copy the package `config/lscache.php` file to your `config/` directory.
-
-**important**: Do not add the ServiceProvider under `providers` in `config/app.php`.
-
-#### Steps for Laravel 5.5 and above
+#### Steps for Laravel 5.5 – 10 (legacy)
 
 You should publish the package configuration, which allows you to set the defaults for the `X-LiteSpeed-Cache-Control` header:
 
@@ -61,15 +32,44 @@ You should publish the package configuration, which allows you to set the defaul
 php artisan vendor:publish --provider="Litespeed\LSCache\LSCacheServiceProvider"
 ```
 
-### Enable CacheLookup for LiteSpeed Cache
+#### Steps for Laravel 11 and above
 
-To enable CacheLookup for LiteSpeed Cache, you have to include the following code, either on server, vhost or .htaccess level:
+Laravel 11 removed `app/Http/Kernel.php` and moved middleware registration to `bootstrap/app.php`. This package registers its global middleware automatically via the service provider, so **no manual kernel edits are needed**. Publishing the config is still optional but recommended:
+
+```
+php artisan vendor:publish --provider="Litespeed\LSCache\LSCacheServiceProvider"
+```
+
+### Enable CacheLookup — LiteSpeed Web Server (Enterprise)
+
+To enable CacheLookup for LiteSpeed Cache, add the following to your `.htaccess` (or at server/vhost level in the LiteSpeed admin):
 
 ```apacheconf
 <IfModule LiteSpeed>
    CacheLookup on
 </IfModule>
 ```
+
+### Enable CacheLookup — OpenLiteSpeed
+
+OpenLiteSpeed supports the same LSCache response headers (`X-LiteSpeed-Cache-Control`, `X-LiteSpeed-Tag`, `X-LiteSpeed-Purge`) as the commercial server, so this package works with OpenLiteSpeed without any code changes.
+
+**Required steps in the OpenLiteSpeed admin panel:**
+
+1. Log in to the OLS WebAdmin console (default: `https://your-server:7080`).
+2. Go to **Server** → **Cache** and set **Enable Cache** to `Yes`. Save and perform a graceful restart.
+3. Optionally configure **Cache Storage Path**, **Default Cache TTL**, etc. in the same section.
+4. Add the `CacheLookup` directive to your `.htaccess` (OLS honours `.htaccess` files):
+
+```apacheconf
+<IfModule LiteSpeed>
+   CacheLookup on
+</IfModule>
+```
+
+Or enable it at the virtual-host level via **Virtual Hosts** → (your vhost) → **Cache** → **Enable Cache** = `Yes`.
+
+> **Note:** Cache purge via `X-LiteSpeed-Purge` response headers works in OpenLiteSpeed the same way as in LiteSpeed Enterprise — no extra configuration is needed beyond enabling the cache module.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It provides two middlewares and one facade:
 Require this package using composer.
 
 ```
-composer require litespeed/lscache-laravel
+composer require programmernomad/lscache-laravel
 ```
 
 Laravel uses Auto-Discovery, so you won't have to make any changes to your application, the two middlewares and facade will be available right from the beginning.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "litespeed/lscache-laravel",
-    "description": "LSCache Implementation for Laravel",
+    "name": "programmernomad/lscache-laravel",
+    "description": "LSCache implementation for Laravel with modern Laravel and OpenLiteSpeed support",
     "require": {
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "php": ">=8.1"

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "litespeed/lscache-laravel",
     "description": "LSCache Implementation for Laravel",
     "require": {
-        "illuminate/support": "^5.1|^6|^7|^8|^9|^10.0|^11.0|^12.0|^13.0",
-        "php": ">=5.6"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "php": ">=8.1"
     },
     "license": "GPL-3.0-only",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
     "license": "GPL-3.0-only",
     "authors": [
         {
+            "name": "Nomad Programmer",
+            "email": "shiv@srapsware.com"
+        },
+        {
             "name": "Lucas Rolff",
             "email": "lucas@lucasrolff.com"
         },

--- a/src/LSCacheMiddleware.php
+++ b/src/LSCacheMiddleware.php
@@ -13,7 +13,7 @@ class LSCacheMiddleware
      *
      * @param  \Illuminate\Http\Request $request
      * @param  \Closure                 $next
-     * @param  string                   $lscache_control
+     * @param  string|null              $lscache_control
      * @return mixed
      */
     public function handle($request, Closure $next, ?string $lscache_control = null)
@@ -21,6 +21,9 @@ class LSCacheMiddleware
         $response = $next($request);
 
         if (!in_array($request->getMethod(), ['GET', 'HEAD']) || !$response->getContent()) {
+            // Still flush any purge headers that were queued during this
+            // request (e.g. a POST that triggers a cache purge).
+            $this->flushPurgeHeaders($response);
             return $response;
         }
 
@@ -30,12 +33,13 @@ class LSCacheMiddleware
         $guest_only     = config('lscache.guest_only', false);
 
         if ($maxage === 0 && $lscache_control === null) {
+            $this->flushPurgeHeaders($response);
             return $response;
         }
 
         if ($guest_only && Auth::check()) {
             $response->headers->set('X-LiteSpeed-Cache-Control', 'no-cache');
-
+            $this->flushPurgeHeaders($response);
             return $response;
         }
 
@@ -53,6 +57,32 @@ class LSCacheMiddleware
             $response->headers->set('X-LiteSpeed-Cache-Control', $lscache_string);
         }
 
+        $this->flushPurgeHeaders($response);
+
         return $response;
+    }
+
+    /**
+     * Apply any X-LiteSpeed-Purge headers that were queued by LiteSpeedCache
+     * during the current request lifecycle, then clear the queue.
+     *
+     * Using the response object (instead of PHP's header() function) ensures
+     * compatibility with Laravel Octane (Swoole / RoadRunner) where the PHP
+     * process is long-lived and native header() calls have no effect.
+     * It also works correctly with LiteSpeed Web Server and OpenLiteSpeed,
+     * both of which read purge instructions from the HTTP response headers.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Response $response
+     */
+    protected function flushPurgeHeaders($response): void
+    {
+        foreach (LiteSpeedCache::getPendingPurges() as $purgeValue) {
+            // Pass false as the third argument so that multiple purge calls
+            // within the same request each produce their own header line
+            // rather than overwriting one another.
+            $response->headers->set('X-LiteSpeed-Purge', $purgeValue, false);
+        }
+
+        LiteSpeedCache::clearPendingPurges();
     }
 }

--- a/src/LSCacheServiceProvider.php
+++ b/src/LSCacheServiceProvider.php
@@ -15,7 +15,16 @@ class LSCacheServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        // Make the config defaults available even when the user has not run
+        // vendor:publish yet.
+        $this->mergeConfigFrom(__DIR__ . '/../config/lscache.php', 'lscache');
+
+        // Bind as singleton so that the static $pendingPurges queue in
+        // LiteSpeedCache is always backed by the same resolved instance and
+        // state is not silently discarded between facade calls.
+        $this->app->singleton(LiteSpeedCache::class, function () {
+            return new LiteSpeedCache();
+        });
     }
 
     /**
@@ -27,6 +36,11 @@ class LSCacheServiceProvider extends ServiceProvider
     {
         $router->aliasMiddleware('lscache', LSCacheMiddleware::class);
         $router->aliasMiddleware('lstags', LSTagsMiddleware::class);
+
+        // pushMiddleware is still available in Laravel 11 / 12 / 13 and is the
+        // correct way to register a global middleware from a service provider.
+        // In console / queue contexts the HTTP kernel is still bound in the
+        // container but middleware is never executed, so this is safe.
         $kernel->pushMiddleware(LSCacheMiddleware::class);
 
         $this->publishes([

--- a/src/LiteSpeedCache.php
+++ b/src/LiteSpeedCache.php
@@ -4,38 +4,62 @@ namespace Litespeed\LSCache;
 
 class LiteSpeedCache
 {
-    protected $stale_key;
+    /**
+     * Purge headers queued during the current request lifecycle.
+     * Consumed by LSCacheMiddleware to attach them to the response object,
+     * which makes them work correctly under Laravel Octane (Swoole / RoadRunner)
+     * as well as in standard PHP-FPM deployments.
+     *
+     * @var list<string>
+     */
+    protected static array $pendingPurges = [];
 
-    public function __construct()
+    public function purge(string $items, bool $stale = true): void
     {
-        $this->stale_key = "";
+        // Build the header value without touching any instance state so that
+        // successive calls with different $stale values do not bleed into each
+        // other (the previous implementation had a $stale_key instance property
+        // that was set on stale=true but never reset on stale=false).
+        $headerValue = ($stale ? 'stale,' : '') . $items;
+
+        static::$pendingPurges[] = $headerValue;
     }
 
-    public function purge(string $items, bool $stale = true)
+    public function purgeAll(bool $stale = true): void
     {
-        if($stale === true) {
-            $this->stale_key = "stale,";
-        }
-
-        return header('X-LiteSpeed-Purge: ' . $this->stale_key . $items);
+        $this->purge('*', $stale);
     }
 
-    public function purgeAll($stale = true)
-    {
-        return $this->purge('*', $stale);
-    }
-
-    public function purgeTags(array $tags, $stale = true)
+    public function purgeTags(array $tags, bool $stale = true): void
     {
         if (count($tags)) {
-            return $this->purge(implode(',', array_map(function($tag) { return 'tag=' . $tag; }, $tags)), $stale);
+            $this->purge(implode(',', array_map(fn (string $tag) => 'tag=' . $tag, $tags)), $stale);
         }
     }
 
-    public function purgeItems(array $items, $stale = true)
+    public function purgeItems(array $items, bool $stale = true): void
     {
         if (count($items)) {
-            return $this->purge(implode(',', $items), $stale);
+            $this->purge(implode(',', $items), $stale);
         }
+    }
+
+    /**
+     * Return all purge header values queued since the last flush.
+     *
+     * @return list<string>
+     */
+    public static function getPendingPurges(): array
+    {
+        return static::$pendingPurges;
+    }
+
+    /**
+     * Clear the pending purge queue (called by LSCacheMiddleware after the
+     * headers have been written to the response object).
+     */
+    public static function clearPendingPurges(): void
+    {
+        static::$pendingPurges = [];
     }
 }


### PR DESCRIPTION
1. Replace direct header() calls with queued X-LiteSpeed-Purge values and flush them from middleware so purge headers work reliably in Octane / long-lived PHP processes.
2. Bind LiteSpeedCache as a singleton and merge package config defaults so the package works before vendor:publish.
3. Update composer requirements to modern supported versions: PHP >=8.1 and illuminate/support ^10|^11|^12|^13.
4. Expand README with Laravel 11+ notes and OpenLiteSpeed / LiteSpeed setup guidance.